### PR TITLE
Check receiver in validate id

### DIFF
--- a/src/Vest.sol
+++ b/src/Vest.sol
@@ -205,7 +205,7 @@ abstract contract Vest is IVest, Owned {
 
     /// @dev Validates that the `id` is correct.
     function _validateId(uint256 id) internal view {
-        if (id > _ids) revert InvalidVestingId();
+        if (_vestings[id].receiver == address(0)) revert InvalidVestingId();
     }
 
     /// @dev Returns the unclaimed amount of tokens related to the vesting `id`.

--- a/test/Vest.t.sol
+++ b/test/Vest.t.sol
@@ -248,19 +248,19 @@ contract VestTest is BaseTest {
         vest.create(receiver, start, cliff, duration, manager, restricted, protected, total);
     }
 
-    function testValidateId(uint256 ids, uint256 id) public {
-        ids = bound(ids, 1, type(uint256).max);
-        id = bound(id, 0, ids - 1);
-        stdstore.target(address(vest)).sig("ids()").checked_write(ids);
+    function testValidateId() public {
+        uint256 id = vest.create(alice, START, 0, DURATION, address(0), false, false, TOTAL);
 
         vest.validateId(id);
     }
 
-    function testValidateIdShouldRevertIfIdStrictlySuperiorToIds(uint256 ids, uint256 id) public {
-        ids = bound(ids, 0, type(uint256).max - 1);
-        id = bound(id, ids + 1, type(uint256).max);
-        stdstore.target(address(vest)).sig("ids()").checked_write(ids);
+    function testValidateIdWhenIdIsZero() public {
+        vest.create(alice, START, 0, DURATION, address(0), false, false, TOTAL);
+        vm.expectRevert(Vest.InvalidVestingId.selector);
+        vest.validateId(0);
+    }
 
+    function testValidateIdShouldRevertWhenNotAVesting(uint256 id) public {
         vm.expectRevert(Vest.InvalidVestingId.selector);
         vest.validateId(id);
     }

--- a/test/Vest.t.sol
+++ b/test/Vest.t.sol
@@ -444,7 +444,7 @@ contract VestTest is BaseTest {
     }
 
     function testProtectShouldRevertWhenInvalidId(uint256 id) public {
-        id = bound(id, 2, type(uint256).max);
+        id = _boundId(id);
 
         _createVest();
 
@@ -476,7 +476,7 @@ contract VestTest is BaseTest {
     }
 
     function testUnprotectShouldRevertWhenInvalidId(uint256 id) public {
-        id = bound(id, 2, type(uint256).max);
+        id = _boundId(id);
 
         _createVest();
 
@@ -523,7 +523,7 @@ contract VestTest is BaseTest {
     }
 
     function testRestrictShouldRevertWhenInvalidId(uint256 id) public {
-        id = bound(id, 2, type(uint256).max);
+        id = _boundId(id);
 
         _createVest();
 
@@ -570,7 +570,7 @@ contract VestTest is BaseTest {
     }
 
     function testUnrestrictShouldRevertWhenInvalidId(uint256 id) public {
-        id = bound(id, 2, type(uint256).max);
+        id = _boundId(id);
 
         _createVest();
 
@@ -722,7 +722,7 @@ contract VestTest is BaseTest {
     }
 
     function testRevokeShouldRevertWhenInvalidId(uint256 id) public {
-        id = bound(id, 2, type(uint256).max);
+        id = _boundId(id);
 
         vm.expectRevert(Vest.InvalidVestingId.selector);
         vm.prank(address(this));

--- a/test/helpers/BaseTest.sol
+++ b/test/helpers/BaseTest.sol
@@ -18,4 +18,8 @@ contract BaseTest is Test {
     function _boundAddressNotZero(address input) internal view virtual returns (address) {
         return address(uint160(bound(uint256(uint160(input)), 1, type(uint160).max)));
     }
+
+    function _boundId(uint256 id) internal pure returns (uint256) {
+        return (id == 1) ? 0 : id;
+    }
 }


### PR DESCRIPTION
Fixes #9 

I'm even thinking that _validateId could return the storage pointer of the vesting since it's used everywhere.